### PR TITLE
feat: add openshift

### DIFF
--- a/.github/workflows/publish-to-quay.yml
+++ b/.github/workflows/publish-to-quay.yml
@@ -20,7 +20,20 @@ jobs:
       - name: Create env file
         run: |
           cat << EOF > .env
+          GOOGLE_CLOUD_PROJECT=${{ secrets.GOOGLE_CLOUD_PROJECT }}
           SECRET_KEY=${{ secrets.SECRET_KEY }}
+          APP_ENGINE_URL=${{ secrets.APP_ENGINE_URL }}
+          AZURE_SITES_URL=${{ secrets.AZURE_SITES_URL }}
+          POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
+          POSTGRES_PORT=${{ secrets.POSTGRES_PORT }}
+          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+          SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}
+          SENDGRID_ADMIN_EMAIL=${{ secrets.SENDGRID_ADMIN_EMAIL }}
+          SENDGRID_NO_REPLY_EMAIL=${{ secrets.SENDGRID_NO_REPLY_EMAIL }}
           EOF
 
       - name: Create short-sha

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ ansible/inventory
 
 # Azure
 *.PublishSettings
+
+# OpenShift
+pull-secret.txt
+*secret.yml

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ The image will be pushed to the [`nimbusinformatics/bdcat-data-tracker`](https:/
 The image will be named `quay.io/nimbusinformatics/bdcat-data-tracker` and two tags: `latest` and a shortened commit hash.
 Be sure to include the following in your GitHub Secrets:
 
-| name                 | description                               |
-| -------------------- | ----------------------------------------- |
-| QUAY_NIMBUS_USERNAME | A username with access to Rethe Quay repo |
-| QUAY_NIMBUS_PASSWORD | The password of the Quay user             |
+| name                 | description                             |
+| -------------------- | --------------------------------------- |
+| QUAY_NIMBUS_USERNAME | A username with access to the Quay repo |
+| QUAY_NIMBUS_PASSWORD | The password of the Quay user           |
 
 > NOTE: Robot accounts are the preferred method of pushing images to Quay.
 > These accounts are usually in the format: `<repo-name+<robot-name>`

--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ The image will be pushed to the [`nimbusinformatics/bdcat-data-tracker`](https:/
 The image will be named `quay.io/nimbusinformatics/bdcat-data-tracker` and two tags: `latest` and a shortened commit hash.
 Be sure to include the following in your GitHub Secrets:
 
-| name                 | description                             |
-| -------------------- | --------------------------------------- |
-| QUAY_NIMBUS_USERNAME | A username with access to the Quay repo |
-| QUAY_NIMBUS_PASSWORD | The password of the Quay user           |
+| name                 | description                               |
+| -------------------- | ----------------------------------------- |
+| QUAY_NIMBUS_USERNAME | A username with access to Rethe Quay repo |
+| QUAY_NIMBUS_PASSWORD | The password of the Quay user             |
 
 > NOTE: Robot accounts are the preferred method of pushing images to Quay.
 > These accounts are usually in the format: `<repo-name+<robot-name>`
@@ -148,6 +148,11 @@ docker run -p 8000:8000 quay.io/nimbusinformatics/bdcat-data-tracker:latest
 ```
 
 A more detailed writeup can be found on the [Quay repository](https://quay.io/repository/nimbusinformatics/bdcat-data-tracker?tab=info)
+
+#### Red Hat OpenShift
+
+Red Hat OpenShift can be developed locally, with [Red Hat CodeReady Containers](https://developers.redhat.com/products/codeready-containers/overview).
+You can find a detailed writeup in the [`openshift`](/openshift) directory
 
 #### Microsoft Azure
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
   chmod +x /sbin/tini \
   ; \
   # install py modules
-  pip install --upgrade pip; \
+  pip install -U "pip>=21.1"; \
   pip install -r requirements.txt; \
   # collect static
   python /app/manage.py collectstatic --noinput;

--- a/openshift/BuildConfig.yaml
+++ b/openshift/BuildConfig.yaml
@@ -1,0 +1,61 @@
+# ==============================================================================
+# Application: [Application name, such as Clinical Dashboard]
+# Module (Optional): [module name, such as web frontend]
+# Based on NHLBI BuildConfig Template V1.1
+#
+# Last Update by: [Luan Tran] Last Update date: [03/03/2022]
+# ============================================================================
+#
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: ${APPNAME}-build-config-template
+metadata:
+  annotations:
+    description: ITAC gerneric template for docker strategy based image build
+    tags: python,django,tracker,pipeline
+  name: ${APPNAME}-${VERSION_NUM}
+objects:
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      name: ${APPNAME}-${VERSION_NUM}
+      namespace: ${NAMESPACE}
+      labels:
+        build: ${APPNAME}-${VERSION_NUM}
+    spec:
+      output:
+        to:
+          kind: DockerImage
+          name: ${IMAGE_REGISTRY_URL}/${REGISTRY_NAMESPACE}/${APPNAME}:${VERSION_NUM}
+      resource: {}
+      strategy:
+        type: Docker
+        dockerStrategy:
+          pullSecret:
+            name: ${REGISTRY_SECRET}
+      postCommit: {}
+      source:
+        type: Binary
+        binary: {}
+parameters:
+  - name: APPNAME
+    description: application name or bitbucket repo name
+    required: true
+    value: bdcat-data-tracker
+  - name: VERSION_NUM
+    description: application version number, use number and '-'
+    required: true
+    value: "0-0-1"
+  - name: NAMESPACE
+    description: openshift project name or namespace
+    value: "test"
+  - name: IMAGE_REGISTRY_URL
+    description: registry url for publishing the image
+    value: "quay.io"
+  - name: REGISTRY_SECRET
+    description: secret for registry authentication
+    value: "nonprodacr-secret"
+  - name: REGISTRY_NAMESPACE
+    description: image registry namespace.
+    value: "nimbusinformatics"

--- a/openshift/DeploymentConfig.yaml
+++ b/openshift/DeploymentConfig.yaml
@@ -1,0 +1,158 @@
+# ==============================================================================
+# Application: NHLBI BioData Catalyst Data Tracker
+# Module (Optional): django web app
+# Based on NHLBI DeploymentConfig Template V1.1
+#
+# Last Update by: [Luan Tran] Last Update date: [03/03/2022]
+# ============================================================================
+#
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: ${APPNAME}-${VERSION_NUM}-${ENV}
+metadata:
+  annotations:
+    description: This teamplate is for application deployment
+    tags: python,django,tracker,pipeline
+  name: ${APPNAME}-${VERSION_NUM}-${ENV}
+objects:
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: ${APPNAME}
+        version: ${VERSION_NUM}
+        environment: ${ENV}
+      name: ${APPNAME}-${VERSION_NUM}-${ENV}
+      namespace: ${NAMESPACE}
+    spec:
+      replicas: "${{ REPLICA_COUNT }}"
+      selector:
+        name: ${APPNAME}-${VERSION_NUM}-${ENV}
+      template:
+        metadata:
+          labels:
+            name: ${APPNAME}-${VERSION_NUM}-${ENV}
+            app: ${APPNAME}
+            version: ${VERSION_NUM}
+            environment: ${ENV}
+        spec:
+          containers:
+            - name: ${APPNAME}-${VERSION_NUM}-${ENV}
+              # env: add optional env vars here
+              ports:
+                - containerPort: "${{ CONTAINER_PORT }}"
+                  protocol: TCP
+              image: ${IMAGE_REGISTRY_URL}/${REGISTRY_NAMESPACE}/${APPNAME}:${VERSION_NUM}
+              imagePullPolicy: Always
+              dnsPolicy: ClusterFirst
+              restartPolicy: Always
+              securityContext:
+                capabilities:
+                  drop:
+                    - KILL
+                    - MKNOD
+                    - SETGID
+                    - SETUID
+                  privileged: false
+                  runAsUser: "${{ RUN_AS_USER_ID }}"
+              terminationGracePeriodSeconds: 30
+              volumnMounts:
+                - name: nih-ca-certs
+                  readOnly: true
+                  mountPath: /nihchaincerts
+          volumns:
+            - name: nih-ca-certs
+              secret:
+                secretName: nih-ca-certs
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: ${APPNAME}
+        version: ${VERSION_NUM}
+        environment: ${ENV}
+      name: ${APPNAME}-${VERSION_NUM}-${ENV}
+      namespace: ${NAMESPACE}
+    spec:
+      ports:
+        - name: web-http
+          port: "${{APP_EXPOSED_PORT}}"
+          protocol: TCP
+          targetPort: "${{CONTAINER_PORT}}"
+      selector:
+        name: ${APPNAME}-${VERSION_NUM}-${ENV}
+        app: ${APPNAME}
+        version: ${VERSION_NUM}
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      annotations:
+        haproxy.router.openshift.io/hsts_header: max-age=31536000; includeSubDomains; preload
+      labels:
+        app: ${APPNAME}
+        version: ${VERSION_NUM}
+        environment: ${ENV}
+      name: ${APPNAME}-${VERSION_NUM}-${ENV}
+      namespace: ${NAMESPACE}
+    spec:
+      host: ${APPNAME}-${VERSION_NUM}-${ENV}.${ROUTE_SUFFIX}
+      path: /${APP_CONTEXT}
+      to:
+        kind: Service
+        name: ${APPNAME}-${VERSION_NUM}-${ENV}
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+      wildcardPolicy: None
+parameters:
+  - name: ENV
+    description: application environment
+    required: true
+    value: dev
+  - name: APPNAME
+    description: application name and module name in OpenShift
+    required: true
+    value: bdcat-data-tracker
+  - name: VERSION_NUM
+    description: application version number, use number and '-'
+    required: true
+    value: "0-0-1"
+  - name: REPLICA_COUNT
+    description: count of replicas
+    required: true
+    value: "2"
+  - name: ROUTE_SUFFIX
+    description: suffix for the default router
+    required: true
+    value: "apps-crc.testing" # default to 'apps.nonprodaro.nhlbi.nih.gov'
+  - name: CONTAINER_PORT
+    description: container Port exposed for internal routing
+    required: true
+    value: "8000"
+  - name: APP_EXPOSED_PORT
+    description: Application Port exposed to the external access
+    required: true
+    value: "8000"
+  - name: IMAGE_REGISTRY_URL
+    description: registry url for pulling the image from image registry
+    required: true
+    value: quay.io
+  - name: NAMESPACE
+    description: application target namespace/openshift project name
+    required: true
+    value: "test"
+  - name: REGISTRY_NAMESPACE
+    description: image registry namespace.
+    value: "nimbusinformatics"
+  - name: APP_CONTEXT
+    description: Application context path.
+    value: ""
+  - name: RUN_AS_USER_ID
+    description: Container userid and external file volumn mount uid. the value should get from ARO namespace UUID range
+    displayName: Container userid and external file volumn mount uid
+    value: "1000700000"

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,67 @@
+# Red Hat OpenShift
+
+> These manifest files can be used to deploy to a OpenShift cluster
+
+## Prerequisites
+
+- **[OpenShift CLI](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html)**
+
+> NOTE: The rest of this README will assume you have experience with DevOps concepts and cluster administration
+
+## CodeReady Containers
+
+Currently, the changes are not tested on a live production cluster, but they work on a local OpenShift cluster.
+You can view the console at: [`console-openshift-console.apps-crc.testing`](https://console-openshift-console.apps-crc.testing/)
+
+## Pull Secret
+
+Since the Quay repository is private, you must provide a secret to pull the images from the Quay repository.
+In your Quay Robot Account, download the secret yml file
+
+```
+oc apply -f <secret.yml>
+```
+
+> NOTE: Replace `<secret.yml>` with the name of the file you downloaded
+
+## Deployment
+
+Deployment has been separated into files for each resource.
+
+### [`deployment.yml`](./deployment.yml)
+
+This contains the deployment configuration for the pod with the container running the app
+
+```
+oc apply -f deployment.yml
+```
+
+### [`service.yml`](./service.yml)
+
+This contains the service configuration to redirect internal traffic to the pod
+
+```
+oc apply -f service.yml
+```
+
+### [`route.yml`](./route.yml)
+
+This contains the route configuration to redirect web traffic to the pod
+
+```
+oc apply -f route.yml
+```
+
+### [`DeploymentConfig.yaml`](./DeploymentConfig.yaml)
+
+This not tested, but follow the specs of the resouces above
+
+> NOTE: This is a based off the templates written by Jason Wang
+
+### [`BuildConfig.yaml`](./BuildConfig.yaml)
+
+There is no need to build the image from source, it is already available in the Quay repository.
+The [GitHub Actions Workflow](../.github/workflows/publish-to-quay.yml) is being used to deploy the image to the Quay repository.
+This not tested, but _should_ work
+
+> NOTE: This is a based off the templates written by Jason Wang

--- a/openshift/deployment.yml
+++ b/openshift/deployment.yml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  labels:
+    app: django-app
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: django-app
+  template:
+    metadata:
+      labels:
+        app: django-app
+    spec:
+      containers:
+        - name: app
+          image: quay.io/nimbusinformatics/bdcat-data-tracker:latest
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+      imagePullSecrets:
+        - name: quay-pull-secret
+parameters:
+  - name: ENV
+    description: application environment
+    required: true
+    value: dev
+  - name: APPNAME
+    description: app name for openshift
+    required: true
+    value: bdcat-data-tracker
+  - name: NAMESPACE
+    description: namespace for openshift
+    required: true
+    value: test
+  - name: REPLICA_COUNT
+    description: count of replicas
+    required: true
+    value: "1"
+  - name: CONTAINER_PORT
+    description: port exposed in container
+    required: true
+    value: "8000"
+  - name: IMAGE_REGISTRY_URL
+    description: registry url for latest image
+    required: true
+    value: quay.io/nimbusinformatics/bdcat-data-tracker:latest
+  - name: PULL_SECRET
+    description: pull secret variable name
+    required: true
+    value: nimbusinformatics-bdcat-data-tracker-pull-secret

--- a/openshift/route.yml
+++ b/openshift/route.yml
@@ -1,0 +1,53 @@
+apiVersion: route.openshift.io/v1
+metadata:
+  name: app-route
+  namespace: test
+kind: Route
+spec:
+  host: app-biocat.apps-crc.testing
+  to:
+    kind: Service
+    name: app-service
+  port:
+    targetPort: web-http
+  wildcardPolicy: None
+parameters:
+  - name: ENV
+    description: application environment
+    required: true
+    value: dev
+  - name: APPNAME
+    description: app name for openshift
+    required: true
+    value: bdcat-data-tracker
+  - name: NAMESPACE
+    description: namespace for openshift
+    required: true
+    value: test
+---
+apiVersion: route.openshift.io/v1
+metadata:
+  name: app-route-dev
+  namespace: test
+kind: Route
+spec:
+  host: localhost
+  to:
+    kind: Service
+    name: app-service
+  port:
+    targetPort: web-http
+  wildcardPolicy: None
+parameters:
+  - name: ENV
+    description: application environment
+    required: true
+    value: dev
+  - name: APPNAME
+    description: app name for openshift
+    required: true
+    value: bdcat-data-tracker
+  - name: NAMESPACE
+    description: namespace for openshift
+    required: true
+    value: test

--- a/openshift/service.yml
+++ b/openshift/service.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+metadata:
+  name: app-service
+  namespace: test
+kind: Service
+spec:
+  ports:
+    - name: web-http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: django-app
+parameters:
+  - name: ENV
+    description: application environment
+    required: true
+    value: dev
+  - name: APPNAME
+    description: app name for openshift
+    required: true
+    value: bdcat-data-tracker
+  - name: NAMESPACE
+    description: namespace for openshift
+    required: true
+    value: test
+  - name: CONTAINER_PORT
+    description: port exposed in container
+    required: true
+    value: "8000"
+  - name: EXPOSED_PORT
+    description: port exposed to public
+    required: true
+    value: "8000"


### PR DESCRIPTION
# Summary

Add OpenShift support

## Changelog

- [x] Moved secrets back into a `.env` file in the Quay container
- [x] Added OpenShift manifest files
- [x] Added Jason Wang NHLBI manifests
- [x] Added documentation for OpenShift

## Notes

- The two `yaml` (not `yml`) files are based on the Jason Wang templates. These are not fully tested, but _should_ work
- The decision to move the secrets back into a `.env` file should make the container more cloud agnostic. There has been a lot of debate behind where to put the secrets, but the security concern is negligible as long as the Quay repository is locked down. This will also simplify deployments and make the GitHub secrets into the single-source of truth
- The `parameters` are not used, but should help with replacement later on